### PR TITLE
Add support for new Airplay discovery.

### DIFF
--- a/airplay/browser.js
+++ b/airplay/browser.js
@@ -37,7 +37,7 @@ Browser.prototype.init = function ( options ) {
     var mdnsBrowser = new mdns.Mdns(mdns.tcp('airport'));
     var legacyMdnsBrowser = new mdns.Mdns(mdns.tcp('airplay'));
 
-	var mdnsOnUpdate = function(data) {
+    var mdnsOnUpdate = function(data) {
         var info = data.addresses 
         var name = data.name
         /*


### PR DESCRIPTION
According to @SlashmanX, the mdns service name changed to ‘airport’. So here's a quick fix.
