### PR TITLE
More flexible dependency syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "contributors": [],
   "dependencies": {
-    "mdns-js": "git+ssh://git@github.com:shahriman/node-mdns-js.git",
+    "mdns-js": "shahriman/node-mdns-js",
     "plist-with-patches": "0.5.1"
   },
   "keywords": [


### PR DESCRIPTION
I'm seeing build failures in WebTorrent caused by this dependency.
https://travis-ci.org/feross/webtorrent/builds/38995729

This syntax works the same (fetches from GitHub) but it doesn't mandate ssh.
