### PR TITLE
HLS fixes

### DIFF
--- a/airplay/device.js
+++ b/airplay/device.js
@@ -136,7 +136,7 @@ Device.prototype.play = function(media, position, callback){
     //#TODO: Check if has ffmpeg and if not, go directly to simpleplay
     //
     console.log(typeof(media))
-    self.hls.start( 7001 );
+    self.hls.start( 7001 + this.id );
     if (typeof(media) != 'string'){
         self.hls.setSubtitles(media.subtitles)
         media = media.file


### PR DESCRIPTION
Hi Carlos!

I've found two issues trying to run the last version of `node-airplay-js` with `peerflix`. The last master commit seems like a WIP, but I thought that maybe this results helpful. So, I hope it is.

I'm working on some changes to accept SRT and/or local subtitles, converting them to VTT and hosting the resulting file through `httpHandler`, so the ATV device can access a readable subtitle set coming from a popular sub-format like SRT. Do you want me to open an issue for this? Is this a feature you may consider useful? Or the caller script should take care of what subtitle format is used and where it is located before passing the settings to airplay-js?

Also, if you want me to improve/adapt this changes in any way, just let me know.

Thanks for maintaining this module!