### PR TITLE
Fixed compatibility with newer AppleTV's

### DIFF
--- a/airplay/browser.js
+++ b/airplay/browser.js
@@ -33,58 +33,33 @@ Browser.prototype.init = function ( options ) {
     this.devices = {};
     this.addresses = []
 
-    //var mdnsBrowser = new mdns.Mdns(mdns.tcp('airport'));
-    var browser = new mdns.createBrowser(mdns.tcp('airplay'));
-    //var legacyMdnsBrowser = new mdns.Mdns(mdns.tcp('airplay'));
-
-    var mdnsOnUpdate = function(data) {
-        if(data.port && data.port == 7000 && self.addresses.indexOf(data.addresses[0]) < 0){
-            var info = data.addresses
-            var name = data.fullname
-            self.addresses.push(data.addresses[0])
-            /*
-            if ( !self.isValid( info ) ) {
-                return;
-            }
-
-            var device = self.getDevice( info );
-            if ( device ) {
-                return;
-            }
-            */
-            //if(info.length && name){
-                device = new Device( nextDeviceId++, info , name );
-                device.on( 'ready', function( d ) {
-                    self.emit( 'deviceOn', d );
-                });
-                device.on( 'close', function( d ) {
-                    delete self.devices[ d.id ];
-                    self.emit( 'deviceOff', d );
-                });
-
-                self.devices[ device.id ] = device;
-            //}else{
-            //    console.log("Error adding device: "+JSON.stringify(data))
-            //}
-        }
-    };
-
-    //mdnsBrowser.on('ready', function () {
-    //        mdnsBrowser.discover();
-    //});
+    var browser = mdns.createBrowser(mdns.tcp('airplay'));
 
     browser.on('ready', function () {
-            browser.discover();
-            setInterval(function(){
-                browser.discover();
-            },3000)
+        browser.discover();
     });
 
-    //mdnsBrowser.on('update', mdnsOnUpdate);
-    browser.on('update', mdnsOnUpdate);
-    /*
-    this.browser.on( 'serviceDown', function( info ) {
-        if ( !self.isValid( info ) ) {
+    browser.on('serviceUp', function(data) {
+        if(data.port && data.port == 7000 && self.addresses.indexOf(data.address) < 0){
+            var info = [data.address]
+            var name = data.name
+            self.addresses.push(data.address)
+            
+            device = new Device( nextDeviceId++, info , name );
+            device.on( 'ready', function( d ) {
+                self.emit( 'deviceOn', d );
+            });
+            device.on( 'close', function( d ) {
+                delete self.devices[ d.id ];
+                self.emit( 'deviceOff', d );
+            });
+
+            self.devices[ device.id ] = device;
+        }
+    });
+
+    browser.on('serviceDown', function(info) {
+      if ( !self.isValid( info ) ) {
             return;
         }
 
@@ -92,17 +67,15 @@ Browser.prototype.init = function ( options ) {
         if ( device ) {
             device.close();
         }
-    });*/
+    });
 };
 
 Browser.prototype.start = function () {
-    //this.browser.start();
     this.emit( 'start' );
     return this;
 };
 
 Browser.prototype.stop = function() {
-    this.browser.stop();
     this.emit( 'stop' );
     return this;
 };

--- a/airplay/client.js
+++ b/airplay/client.js
@@ -72,7 +72,7 @@ Client.prototype.ping = function ( force ) {
             'User-Agent: ' + CLIENT_USERAGENT,
             'Content-Length: 0',
             '\n'
-        ].join( '\n' ) + '\n'
+        ].join( '\n' )
     );
 
     this.emit( 'ping', !!force );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "contributors": [],
   "dependencies": {
-    "mdns-js": "*",
+    "mdns-js": "simphax/node-mdns-js",
     "plist-with-patches": "0.5.1"
   },
   "keywords": [


### PR DESCRIPTION
It was a new line too much in the ping command, which made the newer Apple TV firmware to disconnect. It's probably more strict on the protocol than earlier versions.

The mdns-js update is courtesy of tberthe/node-mdns-js which includes several improvements and made it properly discover the newer AppleTV.

Works on OSX 10.11. Needs to be tested on other systems.